### PR TITLE
[EZ] Change path name from 'pickcode' to 'interactive-lessons'

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm run dev
 
 This will get you a dev server running at `http://localhost:3000`!
 
-To access the site, navigate to `http://localhost:3000/pickcode`
+To access the site, navigate to `http://localhost:3000/interactive-lessons`
 
 ## Adding a lesson
 
@@ -88,7 +88,7 @@ Let's say you want to add a lesson about phsyics. The pattern we follow is:
 
 Again, it's probably easiest from here to copy paste from an existing example.
 
-You should be able to go to `http://localhost:3000/pickcode/physics-simulation` and every time you save your code, the app will recompile and you can see the changes!
+You should be able to go to `http://localhost:3000/interactive-lessons/physics-simulation` and every time you save your code, the app will recompile and you can see the changes!
 
 ## Configuring VSCode
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath: "/pickcode",
-  assetPrefix: "/pickcode",
+  basePath: "/interactive-lessons",
+  assetPrefix: "/interactive-lessons",
   trailingSlash: true,
 };
 


### PR DESCRIPTION
### Summary
I'm not really sure why the landing page for our lessons is at the path `pickcode` -> if that's something we want to keep, feel free to close this PR.

Else, it probably makes sense to change it to something like `lessons` or `interactive-lessons`, going under the assumption that we'll host more cool things under the PinCS site.


### Testing
Verified locally that the path is now 'interactive-lessons' 