### PR TITLE
Remove text centering in lesson landing page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -25,7 +25,7 @@ export default function LandingPage({
   return (
     <div className="flex flex-col h-screen items-center gap-6">
       <PincsHeader />
-      <div className="mx-[300px] text-center">
+      <div className="mx-[300px]">
         <h2 className="text-xl font-semibold text-gray-800">Lesson Preview</h2>
         <div className="overflow-auto border border-gray-300 rounded-lg bg-white shadow-md px-8 py-6 h-64">
           {children}


### PR DESCRIPTION
See title
Note that bullet points in preview mode are no longer centered

<img width="1034" height="426" alt="Screenshot 2025-07-14 at 10 39 45 AM" src="https://github.com/user-attachments/assets/a3d0529f-6a64-4efa-b00f-9e4be3b6806f" />
