### PR TITLE
added centered headings

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -32,10 +32,16 @@ export default function LandingPage({
     <div className="flex flex-col h-screen items-center gap-6">
       <PincsHeader />
       <div className="mx-[300px]">
-        <h2 className="text-xl font-semibold text-gray-800">Lesson Preview</h2>
+        <h2 className="text-xl font-semibold text-center text-gray-800">
+          Lesson Preview
+        </h2>
         <div className="overflow-auto border border-gray-300 rounded-lg bg-white shadow-md px-8 py-6 h-64">
           {children}
         </div>
+        <br />
+        <h2 className="text-xl font-semibold text-center text-gray-800">
+          Lesson Description
+        </h2>
         <p className="mt-4">{lessonDescription}</p>
         <div className="flex flex-row justify-between mt-4">
           <PincsButton text="Go to full lesson" onClick={goToLesson} />


### PR DESCRIPTION
Turns out, removing the centered text fixed the bullets but broke the h2.
This refixes the h2 and adds another h2 that explains the text below.