### PR TITLE
use env for base path + Few improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Run prisma migrate to init db. 
 DATABASE_URL="file:./dev.db"
 NEXTAUTH_URL="http://localhost:3000/interactive-lessons"
+NEXT_PUBLIC_APP_BASE_PATH="/interactive-lessons"

--- a/setup-dev.js
+++ b/setup-dev.js
@@ -18,7 +18,7 @@ const { execSync } = require("child_process");
 console.log("Installing dependencies...");
 execSync("npm install", { stdio: "inherit" });
 
-// 2. Copy .env.example to .env.local if not present
+// 2. Copy .env.example to .env if not present
 if (!fs.existsSync(".env")) {
   console.log("Creating .env from .env.example...");
   fs.copyFileSync(".env.example", ".env");

--- a/src/app/ProviderWrapper.tsx
+++ b/src/app/ProviderWrapper.tsx
@@ -4,7 +4,9 @@ import type { ReactNode } from "react";
 
 export default function ({ children }: { children: ReactNode }) {
   return (
-    <SessionProvider basePath="/interactive-lessons/api/auth">
+    <SessionProvider
+      basePath={process.env.NEXT_PUBLIC_APP_BASE_PATH + "/api/auth"}
+    >
       {children}
     </SessionProvider>
   );

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,6 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { NextResponse } from "next/server";
+import {
+  PrismaClientKnownRequestError,
+  PrismaClientValidationError,
+} from "@prisma/client/runtime/library";
 
 // Register for account.
 export async function POST(req: Request) {
@@ -17,10 +21,21 @@ export async function POST(req: Request) {
       data: { first_name, last_name, email, password: hashed, website },
     });
     return NextResponse.json({ user: { id: user.id, email: user.email } });
-  } catch (e) {
-    return NextResponse.json(
-      { error: "User already exists?" },
-      { status: 400 }
-    );
+  } catch (error: any) {
+    if (error instanceof PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        console.error("Error: A user with this email already exists.");
+        throw new Error("Email already in use.");
+      } else {
+        console.error("Prisma Client Known Request Error:", error.message);
+        throw new Error(`Database error: ${error.message}`);
+      }
+    } else if (error instanceof PrismaClientValidationError) {
+      console.error("Prisma Client Validation Error:", error.message);
+      throw new Error(`Validation error: ${error.message}`);
+    } else {
+      console.error("An unexpected error occurred:", error);
+      throw new Error("An unexpected error occurred during user creation.");
+    }
   }
 }

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -25,17 +25,25 @@ export async function POST(req: Request) {
     if (error instanceof PrismaClientKnownRequestError) {
       if (error.code === "P2002") {
         console.error("Error: A user with this email already exists.");
-        throw new Error("Email already in use.");
+        return NextResponse.json(
+          { error: "Email already in use." },
+          { status: 409 }
+        );
       } else {
         console.error("Prisma Client Known Request Error:", error.message);
-        throw new Error(`Database error: ${error.message}`);
+        return NextResponse.json({ error: "Database error" }, { status: 400 });
       }
     } else if (error instanceof PrismaClientValidationError) {
       console.error("Prisma Client Validation Error:", error.message);
-      throw new Error(`Validation error: ${error.message}`);
+      return NextResponse.json({ error: "Validation error" }, { status: 422 });
     } else {
       console.error("An unexpected error occurred:", error);
-      throw new Error("An unexpected error occurred during user creation.");
+      return NextResponse.json(
+        {
+          error: "An unexpected error occurred during user creation",
+        },
+        { status: 400 }
+      );
     }
   }
 }

--- a/src/app/demo/example-lesson/lesson/Example.tsx
+++ b/src/app/demo/example-lesson/lesson/Example.tsx
@@ -119,7 +119,7 @@ export default function Example() {
       </p>
       <a
         className="text-blue-500"
-        href="/interactive-lessons/components-showcase"
+        href={process.env.NEXT_PUBLIC_APP_BASE_PATH + "/components-showcase"}
       >
         Component Showcase
       </a>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,11 +16,11 @@ export default function Login() {
       email,
       password,
       redirect: false,
-      callbackUrl: "/interactive-lessons",
+      callbackUrl: process.env.NEXT_PUBLIC_APP_BASE_PATH ?? "",
     });
 
     if (res?.ok) {
-      router.push(res.url ?? "/interactive-lessons");
+      router.push(res.url ?? process.env.NEXT_PUBLIC_APP_BASE_PATH ?? "");
     } else {
       alert("Login failed");
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,8 +15,6 @@ export default function Home() {
   const [selectedSubjects, setSelectedSubjects] = useState<Tag[]>([]);
   const subjects = Object.values(Subject);
 
-  console.log("session: ", session);
-
   /* TRUE iff the lesson has at least one tag in selectedSubjects AND it's not hidden*/
   const filterLesson = useCallback(
     (lesson: Lesson) => {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -17,11 +17,14 @@ export default function Register() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch("/interactive-lessons/api/register", {
-      method: "POST",
-      body: JSON.stringify(form),
-      headers: { "Content-Type": "application/json" },
-    });
+    const res = await fetch(
+      process.env.NEXT_PUBLIC_APP_BASE_PATH + "/api/register",
+      {
+        method: "POST",
+        body: JSON.stringify(form),
+        headers: { "Content-Type": "application/json" },
+      }
+    );
     if (res.ok) router.push("/login");
     else alert("Registration failed");
   }


### PR DESCRIPTION
### Summary
* Make a client-facing env variable representing the site base path -- and use that for routing and client-side API things. This _shouuuuuld_ let me specify a new base path (i.e. `dev-interactive-lessons`) for a dev environment without a ton of hard coding and git issues down the line.
* Remove `next.config.ts` from our git tracked index (this is the one place where I don't think I can hack with the environment vars). I'm not `.gitignore`ing it because we still need it, we just don't want to track future updates ;)
* Slightly update the prisma errors in the registration backend routine. They'll get sent to the server (not back to the client), but that makes things a bit easier for me in case we have future issues. I'll worry about error handling on the client side in a followup PR
* Remove the console log of session in the home page -- I have confidence that auth works now


### Testing
Go through the dev loop -- delete your .env and re-run `npm run setup-dev`. Verify you can still make an account (it'll delete your dev db) and log in