### PR TITLE
Added SVG diagrams for visual editor

### DIFF
--- a/src/app/lesson-maker/puck.config.tsx
+++ b/src/app/lesson-maker/puck.config.tsx
@@ -505,14 +505,24 @@ export const config: Config = {
     Diagram: {
       fields: {
         title: { ...TextType, label: "Title" },
-        svg: { ...TextArea, label: "SVG Content" },
+        svg: { ...TextArea, label: "SVG content" },
+        actions: {
+          label: "Actions",
+          type: "array",
+          arrayFields: {
+            svgElementId: { ...TextType, label: "SVG element ID" },
+            description: { ...TextArea, label: "Description" },
+          },
+          getItemSummary: (item) => item.svgElementId || "Action",
+        },
       },
       defaultProps: {
         title: "",
         svg: "",
+        actions: [],
       },
-      render: ({ title, svg }) => {
-        return <Diagram title={title} svg={svg}></Diagram>;
+      render: ({ title, svg, actions }) => {
+        return <Diagram title={title} svg={svg} actions={actions} />;
       },
     },
   },

--- a/src/app/lesson-maker/puck.config.tsx
+++ b/src/app/lesson-maker/puck.config.tsx
@@ -507,13 +507,13 @@ export const config: Config = {
         title: { ...TextType, label: "Title" },
         svg: { ...TextArea, label: "SVG content" },
         actions: {
-          label: "Actions",
+          label: "Descriptions (optional)",
           type: "array",
           arrayFields: {
             svgElementId: { ...TextType, label: "SVG element ID" },
             description: { ...TextArea, label: "Description" },
           },
-          getItemSummary: (item) => item.svgElementId || "Action",
+          getItemSummary: (item) => item.svgElementId || "(Empty)",
         },
       },
       defaultProps: {

--- a/src/app/lesson-maker/puck.config.tsx
+++ b/src/app/lesson-maker/puck.config.tsx
@@ -17,6 +17,7 @@ import Animation from "@/components/Animation";
 import Collapsible from "@/components/Collapsible";
 import Image from "@/components/Image";
 import ErrorMessage from "@/components/ErrorMessage";
+import Diagram from "@/components/Diagram";
 
 const BlockColor = {
   label: "Slide Color",
@@ -501,6 +502,19 @@ export const config: Config = {
         );
       },
     },
+    Diagram: {
+      fields: {
+        title: { ...TextType, label: "Title" },
+        svg: { ...TextArea, label: "SVG Content" },
+      },
+      defaultProps: {
+        title: "",
+        svg: "",
+      },
+      render: ({ title, svg }) => {
+        return <Diagram title={title} svg={svg}></Diagram>;
+      },
+    },
   },
   categories: {
     basics: {
@@ -514,7 +528,7 @@ export const config: Config = {
       components: ["Pickcode", "Embed", "Animation", "Collapsible", "Image"],
     },
     advanced: {
-      components: ["Custom", "Unity"],
+      components: ["Custom", "Unity", "Diagram"],
     },
   },
   root: {

--- a/src/components/Diagram.tsx
+++ b/src/components/Diagram.tsx
@@ -4,6 +4,7 @@ import ColorBox from "./ColorBox";
 import Text from "./Text";
 import path from "path";
 import { usePathname } from "next/navigation";
+import ErrorMessage from "./ErrorMessage";
 
 export interface DiagramProps {
   title: string;
@@ -21,6 +22,7 @@ export function Diagram({ title, svg, actions = [] }: DiagramProps) {
   const svgContainerRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
 
+  // Get a clean SVG.
   const sanitizedSvg = useMemo(() => {
     if (typeof window !== "undefined") {
       return DOMPurify.sanitize(svg, {
@@ -30,13 +32,13 @@ export function Diagram({ title, svg, actions = [] }: DiagramProps) {
     return svg;
   }, [svg]);
 
+  // Scale the SVG & add action listeners.
   useEffect(() => {
     if (!svgContainerRef.current) return;
 
     const svgElement = svgContainerRef.current.querySelector("svg");
     if (!svgElement) return;
 
-    // --- Robust SVG Scaling ---
     const width = svgElement.getAttribute("width");
     const height = svgElement.getAttribute("height");
 
@@ -97,12 +99,21 @@ export function Diagram({ title, svg, actions = [] }: DiagramProps) {
     };
   }, [sanitizedSvg, actions, selectedDescription]);
 
-  const hasActions = actions && actions.length > 0;
+  // Check for valid inputs.
+  if (title.trim() == "") {
+    return <ErrorMessage message={"Please provide an SVG title."} />;
+  }
+  if (svg.trim() == "") {
+    return <ErrorMessage message={"Please provide a valid SVG."} />;
+  }
 
+  // Get information toggles.
+  const hasActions = actions && actions.length > 0;
   const lessonMakerMode =
     pathname.split("/").includes("lesson-maker") &&
     !pathname.includes("preview");
 
+  // If all's good, show the diagram.
   return (
     <div className="diagram-container my-4">
       <h2 className="text-2xl font-bold text-center mb-6">{title}</h2>

--- a/src/components/Diagram.tsx
+++ b/src/components/Diagram.tsx
@@ -1,0 +1,49 @@
+import { memo } from "react";
+import Emphasize from "./Emphasize";
+import ErrorMessage from "./ErrorMessage";
+import DOMPurify from "dompurify";
+
+const SVG = memo(function ({ svg }: { svg: string }) {
+  // Make sure it's a friendly SVG.
+  const sanitizedHtml = DOMPurify.sanitize(svg, {
+    USE_PROFILES: { svg: true },
+    FORBID_TAGS: ["foreignObject", "script", "iframe"],
+    FORBID_ATTR: ["onload", "onerror", "onclick", "xlink:href", "href"],
+  });
+
+  return <div dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />;
+});
+
+export default function Diagram({
+  title,
+  svg,
+}: {
+  title: string;
+  svg: string;
+}) {
+  if (title.trim() == "") {
+    return (
+      <ErrorMessage
+        message={"You must have a title on your SVG."}
+        pulsing={true}
+      ></ErrorMessage>
+    );
+  }
+  if (svg.trim() == "") {
+    return (
+      <ErrorMessage
+        message={"You must have a valid SVG."}
+        pulsing={true}
+      ></ErrorMessage>
+    );
+  }
+
+  return (
+    <div>
+      <div>
+        <Emphasize>{title}</Emphasize>
+      </div>
+      <SVG svg={svg} />
+    </div>
+  );
+}


### PR DESCRIPTION
You can now add an SVG ([you can make one here and copy optimized SVG](https://www.svgplayground.com)) to a visually made lesson.

Whatever elements have IDs can have descriptions added to them (they're called actions behind the scenes because we may want to add more actions, e.g. highlight or reveal or whatever else).