### PR TITLE
"Fix" session redirect issue

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,25 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   basePath: "/interactive-lessons",
   assetPrefix: "/interactive-lessons",
+  skipTrailingSlashRedirect: true,
+  skipMiddlewareUrlNormalize: true,
+  async rewrites() {
+    return [
+      { source: "/api/auth/", destination: "/api/auth" },
+      { source: "/api/auth/:path*/", destination: "/api/auth/:path*" },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: "/api/auth/:path*",
+        headers: [
+          { key: "Cache-Control", value: "no-store, max-age=0" },
+          { key: "Vary", value: "Cookie" },
+        ],
+      },
+    ];
+  },
   experimental: {
     turbo: {
       rules: {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -50,3 +50,7 @@ const authOptions: NextAuthOptions = {
 };
 const handler = NextAuth(authOptions);
 export { handler as GET, handler as POST };
+
+// Ensure cache is disabled for all auth endpoints
+export const dynamic = "force-dynamic";
+export const revalidate = 0;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+// src/middleware.ts
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export const config = { matcher: ["/api/auth/:path*"] };
+
+export function middleware(req: NextRequest) {
+  // Replace trailing slash in URL to prevent path ping-ponging.
+  const p = req.nextUrl.pathname; // e.g. "/api/auth/session"
+  if (p.endsWith("/") && p !== "/api/auth/") {
+    const url = req.nextUrl.clone();
+    url.pathname = p.replace(/\/+$/, "");
+    return NextResponse.rewrite(url);
+  }
+  return NextResponse.next();
+}


### PR DESCRIPTION
We were observing an issue where some of the auth requests (specifically the session request) were failing, due to redirects between

`path/`
and 
`path`

It seems like there was some browser caching of a path that next didn't like, which was causing a bunch of redirects. I updated our next config (which I'll need to manually propagate to our servers...) and added some middleware (which will be helpful for later when I want to do auth-based routing), and I *believe* the problem is fixed. If we're still seeing issues after a first cookie refresh, I'll need to look into how our reverse proxy is doing things... but fingers crossed....